### PR TITLE
Create vmware_esxi_nic_mellanox15mins_issue.cfg

### DIFF
--- a/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/files/queries/vmware/vmware_esxi_nic_mellanox15mins_issue.cfg
+++ b/prometheus-exporters/octobus-query-exporter/vendor/octobus-query-exporter/files/queries/vmware/vmware_esxi_nic_mellanox15mins_issue.cfg
@@ -1,0 +1,21 @@
+[query_elasticsearch_octobus_Mellanox_issue]
+QueryIndices = c0001_log*
+QueryOnMissing = drop
+QueryJson = {
+      "size": 0,
+      "aggs": {
+          "hostsystem": { "terms": { "field": "syslog_hostname.keyword" }}
+      },
+      "query": {
+          "bool": {
+              "must": [
+                  { "match_phrase": { "syslog_message": "Health: Miss counters detected" }},
+                  { "match": { "syslog_message": "NMLX_ERR" }}
+              ],
+              "filter": [
+                  { "term": { "sap.cc.audit.source.keyword": "ESXi" }},
+                  { "range": { "@timestamp": { "gte": "now-15m" }}}
+              ]
+          }
+      }
+  }


### PR DESCRIPTION
create a new mellanox config with 15mins interval to eliminate the double/triple mellanox alerts on slack & the phone call to oncall person. it used for testing purpose, once it works, we will change this production config "vmware_esxi_nic_mellanox_issue.cfg" with 15 mins